### PR TITLE
Set full path on emitted vinyl file. Fixes #8

### DIFF
--- a/lib/pack.js
+++ b/lib/pack.js
@@ -4,6 +4,7 @@ var octo = require('@octopusdeploy/octopackjs');
 var gutil = require('gulp-util');
 var through = require('through2');
 var log = require('plugin-log');
+var path = require('path');
 
 var PLUGIN_NAME = 'gulp-octo.pack';
 
@@ -25,12 +26,10 @@ module.exports = function (type, options) {
     }
 
     pack.toStream(function (err, data) {
-      objStream.push(new gutil.File({
-        cwd: firstFile.cwd,
-        base: firstFile.base,
-        path: data.name,
-        contents: data.stream
-      }));
+      var packFile = firstFile.clone({contents:false});
+      packFile.path = path.join(packFile.base, data.name);
+      packFile.contents = data.stream;
+      objStream.push(packFile);
 
       log('Packed \'' + log.colors.cyan(data.name) + '\' with ' + log.colors.magenta(Object.keys(files).length + ' files'));
       cb();


### PR DESCRIPTION
This fixes #8.

The changed code basically does the same thing that [`gulp-concat` does](https://github.com/contra/gulp-concat/blob/9db55f5/index.js#L84) to generate a single file from a stream of files (except that it clones the first file instead of the last file in the stream).

Considering that `gulp-concat` is one of the most heavily used gulp plugins, this should be pretty safe.