### PR TITLE
Full path on outputted file stream. Fixes #8

### DIFF
--- a/lib/pack.js
+++ b/lib/pack.js
@@ -4,6 +4,7 @@ var octo = require('@octopusdeploy/octopackjs');
 var gutil = require('gulp-util');
 var through = require('through2');
 var log = require('plugin-log');
+var path = require('path');
 
 var PLUGIN_NAME = 'gulp-octo.pack';
 
@@ -25,12 +26,11 @@ module.exports = function (type, options) {
     }
 
     pack.toStream(function (err, data) {
-      objStream.push(new gutil.File({
-        cwd: firstFile.cwd,
-        base: firstFile.base,
-        path: data.name,
-        contents: data.stream
-      }));
+
+      var packFile = firstFile.clone({contents:false});
+      packFile.path = path.join(packFile.base, data.name);
+      packFile.contents = data.stream;
+      objStream.push(packFile);
 
       log('Packed \'' + log.colors.cyan(data.name) + '\' with ' + log.colors.magenta(Object.keys(files).length + ' files'));
       cb();


### PR DESCRIPTION
As inspired by @svenschoenung and contra/gulp-concat, this takes the firstFile and creates a clone with the provided path allowing output file to be correctly located.

Fixes #8.
